### PR TITLE
PEP8 cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ to the `IndeedClient` constructor.
 ```python
 from indeed import IndeedClient
 
-client = IndeedClient(publisher = YOUR_PUBLISHER_NUMBER)
+client = IndeedClient(publisher=YOUR_PUBLISHER_NUMBER)
 ```
 
 If you do not have a publisher number, you can receive one by heading to the
@@ -37,10 +37,10 @@ from indeed import IndeedClient
 client = IndeedClient('YOUR_PUBLISHER_NUMBER')
 
 params = {
-    'q' : "python",
-    'l' : "austin",
-    'userip' : "1.2.3.4",
-    'useragent' : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2)"
+    'q': "python",
+    'l': "austin",
+    'userip': "1.2.3.4",
+    'useragent': "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2)"
 }
 
 search_response = client.search(**params)
@@ -53,7 +53,7 @@ from indeed import IndeedClient
 
 client = IndeedClient('YOUR_PUBLISHER_NUMBER')
 
-job_response = client.jobs(jobkeys = ("5898e9d8f5c0593f", "c2c41f024581eae5"))
+job_response = client.jobs(jobkeys=("5898e9d8f5c0593f", "c2c41f024581eae5"))
 ```
 
 ## API Paramaters

--- a/indeed/__init__.py
+++ b/indeed/__init__.py
@@ -1,15 +1,24 @@
 import requests
 
-DEFAULT_FORMAT = "json"
-API_ROOT = "http://api.indeed.com/ads"
-API_SEARCH = {'end_point': "%s/apisearch" % API_ROOT, 'required_fields': ['userip', 'useragent', ['q', 'l']]}
-API_JOBS = {'end_point': "%s/apigetjobs" % API_ROOT, 'required_fields': ['jobkeys']}
+
+DEFAULT_FORMAT = 'json'
+API_ROOT = 'http://api.indeed.com/ads'
+API_SEARCH = {
+    'end_point': '{base}/apisearch'.format(base=API_ROOT),
+    'required_fields': ['userip', 'useragent', ['q', 'l']]
+}
+API_JOBS = {
+    'end_point': '{base}/apigetjobs'.format(base=API_ROOT),
+    'required_fields': ['jobkeys']
+}
+
 
 class IndeedClientException(Exception):
     pass
 
+
 class IndeedClient:
-    def __init__(self, publisher, version = "2"):
+    def __init__(self, publisher, version='2'):
         self.publisher = publisher
         self.version = version
 
@@ -18,24 +27,27 @@ class IndeedClient:
 
     def jobs(self, **args):
         valid_args = self.__valid_args(API_JOBS.get('required_fields'), args)
-        valid_args['jobkeys'] = ",".join(valid_args['jobkeys'])
+        valid_args['jobkeys'] = ','.join(valid_args['jobkeys'])
+
         return self.__process_request(API_JOBS.get('end_point'), valid_args)
 
     def __process_request(self, endpoint, args):
         format = args.get('format', DEFAULT_FORMAT)
         raw = True if format == 'xml' else args.get('raw', False)
         args.update({'v': self.version, 'publisher': self.publisher, 'format': format})
-        r = requests.get(endpoint, params = args)
+        r = requests.get(endpoint, params=args)
+
         return r.json() if not raw else r.content
 
     def __valid_args(self, required_fields, args):
         for field in required_fields:
             if type(field) is list:
-                validation_list = [args.get(f) != None for f in field]
+                validation_list = [args.get(f) is not None for f in field]
+
                 if not (True in validation_list):
-                    raise IndeedClientException("You must provide one of the following %s" % ",".join(field))
+                    raise IndeedClientException('You must provide one of the following {fields}'.format(fields=','.join(field)))
+
             elif not args.get(field):
-                raise IndeedClientException("The field %s is required" % field)
+                raise IndeedClientException('The field {field} is required'.format(field=field))
+
         return args
-
-


### PR DESCRIPTION
Applies some PEP8 cleanup (i.e., removing spaces around '=' in function arguments; using a consistent string quote character; and using new-style string formatting), along with a little bit of formatting for readability.
